### PR TITLE
Fix import failure with modern Werkzeug

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,17 @@
+from urllib.parse import urlencode
+import werkzeug.urls
+
+# Older versions of :mod:`flask_wtf` relied on :func:`werkzeug.urls.url_encode`.
+# This function was removed in Werkzeug 3 which ships in the current
+# environment.  To keep the application working without pinning an older
+# Werkzeug we provide a small compatibility shim before importing
+# ``flask_wtf``.
+if not hasattr(werkzeug.urls, "url_encode"):
+    def _url_encode(obj, charset="utf-8", sort=False, key=None, separator="&"):
+        return urlencode(obj)
+
+    werkzeug.urls.url_encode = _url_encode
+
 from flask import Flask, render_template, url_for, redirect, flash
 from flask_bootstrap import Bootstrap
 from flask_wtf import FlaskForm


### PR DESCRIPTION
## Summary
- patch `werkzeug.urls.url_encode` for compatibility

## Testing
- `python3 main.py > /tmp/app.log 2>&1 && sleep 2`

------
https://chatgpt.com/codex/tasks/task_e_688c2a46cf1c8323ae6ea5f8f65453b3